### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -97,6 +97,8 @@ jobs:
   radon:
     name: Radon Complexity Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Potential fix for [https://github.com/vishalbuilds/LambdaCore/security/code-scanning/7](https://github.com/vishalbuilds/LambdaCore/security/code-scanning/7)

The best way to fix the issue is to add a `permissions:` block to the relevant job (in this case, `radon`), specifying only the minimum required privilege. For static analysis jobs that only need to read the source code, setting `permissions: { contents: read }` is sufficient and safest. This ensures the GITHUB_TOKEN is only usable for read operations. The change should be made within the `.github/workflows/python-ci.yml` file, adding the following lines to the `radon` job definition (after `runs-on: ubuntu-latest` and before `steps:`):

```yaml
permissions:
  contents: read
```
No additional methods, imports, or definitions are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
