### PR TITLE
feature: Add .dockerignore; remove tests from Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+test*
+docs/__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.git
+.env
+tests/
+docs/
+.coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ RUN pip install --no-cache-dir -r ${LAMBDA_TASK_ROOT}/requirements.txt
 # Copy application code 
 COPY src/ ${LAMBDA_TASK_ROOT}/
 
-# Run unit tests 
-RUN python -m pytest ${LAMBDA_TASK_ROOT}/test_unit/ -v --tb=short
-
 # Build arguments and labels
 ARG build=local-dev
 LABEL build=$build \

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,8 +2,3 @@
 boto3==1.34.84
 botocore>=1.34.84,<2.0.0  # Pin botocore to match boto3 version range
 phonenumbers>=9.0.0
-
-
-# === Testing & Coverage ===
-pytest==8.2.0
-coverage==7.5.1


### PR DESCRIPTION
Add a .dockerignore to exclude caches, test artifacts, docs, .git, .env and coverage files from the build context. Remove the RUN pytest step from the Dockerfile so unit tests are no longer executed during image build. Remove testing dependencies (pytest, coverage) from src/requirements.txt so the container requirements only include runtime packages. These changes speed up image builds and keep test/CI concerns out of the production image.

# Pull Request Template

## Description
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.  
Fixes # (issue)

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Code cleanup

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional Notes
Add any other context or screenshots about the pull request here.
